### PR TITLE
rails 4.2 configuration removal raise_in_transactional_callbacks

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,8 +19,5 @@ module Artfactum
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
   end
 end


### PR DESCRIPTION
This was preventing the application from running due to #10 in the commit where rails was downgraded.
